### PR TITLE
fix: fix Vue Router bug that throws an exception in the console

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,6 +3,22 @@ import VueRouter from "vue-router";
 import Root from "../views/Root.vue";
 import AuthMiddleware from "./auth.guard";
 
+// avoid NavigationDuplicated
+// https://github.com/vuejs/vue-router/issues/2881#issuecomment-520554378
+const originalPush = VueRouter.prototype.push;
+VueRouter.prototype.push = function push(location, onResolve, onReject) {
+  if (onResolve || onReject)
+    return originalPush.call(this, location, onResolve, onReject);
+  return originalPush.call(this, location).catch((err) => {
+    if (VueRouter.isNavigationFailure(err)) {
+      // resolve err
+      return err;
+    }
+    // rethrow error
+    return Promise.reject(err);
+  });
+};
+
 Vue.use(VueRouter);
 
 const routes = [


### PR DESCRIPTION
This fix avoids an exception to pop-up in the console. Eg: navigate to the Home page from the Home page. This is an [existing issue](https://github.com/vuejs/vue-router/issues/2881#issuecomment-520554378) in the Vue Router module.